### PR TITLE
Fix error when filled_quantity is negative in broker.py

### DIFF
--- a/lumibot/brokers/broker.py
+++ b/lumibot/brokers/broker.py
@@ -1169,12 +1169,10 @@ class Broker(ABC):
 
         if filled_quantity is not None:
             error = ValueError(
-                f"filled_quantity must be a positive integer or float, received {filled_quantity} instead")
+                f"filled_quantity must be an integer or float, received {filled_quantity} instead")
             try:
                 if not isinstance(filled_quantity, float):
                     filled_quantity = float(filled_quantity)
-                if filled_quantity < 0:
-                    raise error
             except ValueError:
                 raise error
 


### PR DESCRIPTION
It appears that filled_quantity is not anymore positive, so the code should be updated.

This causes me a lot of error printing in backtesting and even wrong backtest results.

This is my first PR on lumibot, please correct me if i'm wrong.  